### PR TITLE
T6699: Use `?action` URL parameter instead of subpages

### DIFF
--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -75,9 +75,15 @@ class DataDumpPager extends TablePager {
 					$this->getLanguage()->formatSize( isset( $row->dumps_size ) ? $row->dumps_size : 0 ) );
 				break;
 			case 'dumps_delete':
-				$url = SpecialPage::getTitleFor( 'DataDump' )->getFullUrl() .
-					"/delete/{$row->dumps_type}/{$row->dumps_filename}";
-				$formatted = Linker::makeExternalLink( $url, wfMessage( 'datadump-delete-button' )->text() );
+				$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+
+				$query = [
+					'action' => 'delete',
+					'type' => $row->dumps_type,
+					'dump' => $row->dumps_filename
+				];
+
+				$formatted = $linkRenderer->makeLink( $this->pageTitle, wfMessage( 'datadump-delete-button' )->text(), [], $query );
 				break;
 			default:
 				$formatted = "Unable to format $name";
@@ -147,12 +153,6 @@ class DataDumpPager extends TablePager {
 			$out->addHTML(
 				Html::errorBox( wfMessage( 'datadump-generated-disabled' )->escaped() )
 			);
-
-			$out->addHTML( 
-				'<br />' . Linker::specialLink( 'DataDump', 'datadump-refresh' ) 
-			);
-
-			return true;
 		}
 
 		$dataDumpConfig = $this->config->get( 'DataDump' );
@@ -257,8 +257,13 @@ class DataDumpPager extends TablePager {
 			return Linker::makeExternalLink( $url, $row->dumps_filename );
 		}
 
-		$url = SpecialPage::getTitleFor( 'DataDump' )->getFullUrl() .
-				"/download/{$row->dumps_filename}";
-		return Linker::makeExternalLink( $url, $row->dumps_filename );
+		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+
+		$query = [
+			'action' => 'download',
+			'dump' => $row->dumps_filename
+		];
+
+		return $linkRenderer->makeLink( $this->pageTitle, $row->dumps_filename, [], $query );
 	}
 }

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -153,6 +153,12 @@ class DataDumpPager extends TablePager {
 			$out->addHTML(
 				Html::errorBox( wfMessage( 'datadump-generated-disabled' )->escaped() )
 			);
+
+			$out->addHTML( 
+				'<br />' . Linker::specialLink( 'DataDump', 'datadump-refresh' ) 
+			);
+
+			return true;
 		}
 
 		$dataDumpConfig = $this->config->get( 'DataDump' );

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -77,9 +77,14 @@ class ApiViewDumps extends ApiBase {
 			return Linker::makeExternalLink( $url, $row->dumps_filename );
 		}
 		
-		$url = SpecialPage::getTitleFor( 'DataDump' )->getFullUrl() .
-				"/download/{$row->dumps_filename}";
-		return Linker::makeExternalLink( $url, $row->dumps_filename );
+		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+
+		$query = [
+			'action' => 'download',
+			'dump' => $row->dumps_filename
+		];
+
+		return $linkRenderer->makeLink( $this->pageTitle, $row->dumps_filename, [], $query );
 	}
 
 	public function getAllowedParams() {

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -79,12 +79,14 @@ class ApiViewDumps extends ApiBase {
 		
 		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 
+		$title = SpecialPage::getTitleFor( 'DataDump' );
+
 		$query = [
 			'action' => 'download',
 			'dump' => $row->dumps_filename
 		];
 
-		return $linkRenderer->makeLink( $this->pageTitle, $row->dumps_filename, [], $query );
+		return $linkRenderer->makeLink( $title, $row->dumps_filename, [], $query );
 	}
 
 	public function getAllowedParams() {

--- a/includes/specials/SpecialDataDump.php
+++ b/includes/specials/SpecialDataDump.php
@@ -28,6 +28,8 @@ class SpecialDataDump extends SpecialPage {
 		$this->checkPermissions();
 
 		$out = $this->getOutput();
+	
+		$request = $this->getRequest();
 
 		$dataDumpConfig = $this->config->get( 'DataDump' );
 		if ( !$dataDumpConfig ) {
@@ -42,15 +44,15 @@ class SpecialDataDump extends SpecialPage {
 			$out->addWikiMsg( $dataDumpInfo );
 		}
 
-		if ( !is_null( $par ) && $par !== '' ) {
-			$par = explode( '/', $par );
+		$action = $request->getVal( 'action' );
+		if ( $action ) {
+			$dump = $request->getVal( 'dump' );
+			$type = $request->getVal( 'type' );
 
-			if ( $par[0] === 'download' && isset( $par[1] ) ) {
-				$this->doDownload( $par[1] );
-				return;
-			} else if ( $par[0] === 'delete' && isset( $par[1] ) && isset( $par[2] ) ) {
-				$this->doDelete( $par[1], $par[2] );
-				return;
+			if ( $action === 'download' && $dump ) {
+				$this->doDownload( $dump );
+			} elseif ( $action === 'delete' && $type && $dump ) {
+				$this->doDelete( $type, $dump );
 			}
 		}
 
@@ -60,10 +62,6 @@ class SpecialDataDump extends SpecialPage {
 
 		$pager->getForm();
 		$out->addParserOutputContent( $pager->getFullOutput() );
-		
-		$out->addHTML( 
-			'<br />' . Linker::specialLink( 'DataDump', 'datadump-refresh' ) 
-		);
 	}
 
 	private function doDownload( string $fileName ) {
@@ -123,7 +121,6 @@ class SpecialDataDump extends SpecialPage {
 	}
 
 	private function onDeleteDump( $dbw, $fileName ) {
-
 		$logEntry = new ManualLogEntry( 'datadump', 'delete' );
 		$logEntry->setPerformer( $this->getUser() );
 		$logEntry->setTarget( $this->getPageTitle() );
@@ -142,10 +139,6 @@ class SpecialDataDump extends SpecialPage {
 		$this->getOutput()->addHTML(
 			Html::successBox( wfMessage( 'datadump-delete-success' )->escaped() ) 
 		);
-		
-		$this->getOutput()->addHTML( 
-			'<br />' . Linker::specialLink( 'DataDump', 'datadump-refresh' ) 
-		);
 	}
 
 	private function onDeleteFailureDump( $dbw, $fileName ) {
@@ -162,10 +155,6 @@ class SpecialDataDump extends SpecialPage {
 
 		$this->getOutput()->addHTML(
 			Html::errorBox( wfMessage( 'datadump-delete-failed' )->escaped() ) 
-		);
-		
-		$this->getOutput()->addHTML(
-			'<br />' . Linker::specialLink( 'DataDump', 'datadump-refresh' ) 
 		);
 	}
 


### PR DESCRIPTION
Converts DataDump to use `?action=download&dump=dump_filename` and `?action=delete&type=dump_type&dump=dump_filename`

Also removes the `datadump-refresh` links from SpecialDataDump because they are no longer necessary, as it removes the `return;` after the `doDownload()` and `doDelete()` functions, so instead it now returns the error/success messages at the top of the page without removing the form, allowing for instantly taking additional actions.