### PR TITLE
Support more customisation in the DataDump config

### DIFF
--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -227,7 +227,7 @@ class DataDumpPager extends TablePager {
 				$jobParams = [
 					'fileName' => $fileName,
 					'type' => $type,
-					'arguments' => $args[$type]['generate']['options'] ?? []
+					'arguments' => $args[$type]['generate']['arguments'][0] ?? []
 				];
 
 				$job = new DataDumpGenerateJob(

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -137,6 +137,18 @@ class DataDumpPager extends TablePager {
 			],
 		];
 
+		foreach ( $dataDumpConfig as $name => $value ) {
+			$type = $dataDumpConfig[$name];
+
+			if ( !( $type['htmlform'] ?? false ) ) {
+				continue;
+			}
+
+			$htmlform = $type['htmlform'];
+
+			$formDescriptor[ $htmlform['name'] ] = $htmlform;
+		}
+
 		$htmlFormGenerate = HTMLForm::factory( 'ooui', $formDescriptor, $this->getContext(), 'searchForms' );
 		$htmlFormGenerate->setMethod( 'post' )
 			->setFormIdentifier( 'generateDumpForm' )
@@ -163,6 +175,21 @@ class DataDumpPager extends TablePager {
 
 		$dataDumpConfig = $this->config->get( 'DataDump' );
 		$dbName = $this->config->get( 'DBname' );
+
+		foreach ( $dataDumpConfig as $name => $value ) {
+			$type = $dataDumpConfig[$name];
+
+			if ( !( $type['htmlform'] ?? false ) ) {
+				continue;
+			}
+
+			$arguments = $type['generate']['arguments'] ?? [];
+			$htmlform = $type['htmlform'];
+
+			foreach ( $arguments as $arg => $value ) {
+				$this->config->get( 'DataDump' )[$name]['generate']['arguments'][$arg] = $htmlform['value'] . $params[ $htmlform['name'] ];
+			}
+		}
 
 		$type = $params['generatedump'];
 		if ( !is_null( $type ) && $type !== '' ) {

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -186,7 +186,7 @@ class DataDumpPager extends TablePager {
 			$arguments = $type['generate']['arguments'] ?? [];
 			$htmlform = $type['htmlform'];
 			
-			if ( $htmlform['noArgsValue'] == $params[ $htmlform['name'] ] )
+			if ( $htmlform['noArgsValue'] == $params[ $htmlform['name'] ] ) {
 				continue;	
 			}
 

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -187,7 +187,7 @@ class DataDumpPager extends TablePager {
 			$htmlform = $type['htmlform'];
 
 			foreach ( $arguments as $arg => $value ) {
-				$args[$name]['generate']['arguments'][$arg] = [ $value, $htmlform['value'] . $params[ $htmlform['name'] ] ];
+				$args[$name]['generate']['arguments'][$arg] = $value . '=' . $htmlform['value'] . $params[ $htmlform['name'] ];
 			}
 		}
 
@@ -229,6 +229,8 @@ class DataDumpPager extends TablePager {
 					'type' => $type,
 					'arguments' => $args[$type]['generate']['arguments'][0] ?? []
 				];
+				
+				print_r($jobParams['arguments']);
 
 				$job = new DataDumpGenerateJob(
 					Title::newFromText( 'Special:DataDump' ), $jobParams );

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -187,7 +187,7 @@ class DataDumpPager extends TablePager {
 			$htmlform = $type['htmlform'];
 
 			foreach ( $arguments as $arg => $value ) {
-				$this->config->get( 'DataDump' )[$name]['generate']['arguments'][$arg] = $htmlform['value'] . $params[ $htmlform['name'] ];
+				$arguments[$name]['generate']['arguments'][$arg] = $htmlform['value'] . $params[ $htmlform['name'] ];
 			}
 		}
 
@@ -227,6 +227,7 @@ class DataDumpPager extends TablePager {
 				$jobParams = [
 					'fileName' => $fileName,
 					'type' => $type,
+					'arguments' => $arguments ?? []
 				];
 
 				$job = new DataDumpGenerateJob(

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -227,7 +227,7 @@ class DataDumpPager extends TablePager {
 				$jobParams = [
 					'fileName' => $fileName,
 					'type' => $type,
-					'arguments' => $args[$type]['generate']['arguments'][0] ?? []
+					'arguments' => $args[$type]['generate']['arguments'] ?? []
 				];
 				
 				print_r($jobParams['arguments']);

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -187,7 +187,7 @@ class DataDumpPager extends TablePager {
 			$htmlform = $type['htmlform'];
 
 			foreach ( $arguments as $arg => $value ) {
-				$arguments[$name]['generate']['arguments'][$arg] = $htmlform['value'] . $params[ $htmlform['name'] ];
+				$args[$name]['generate']['arguments'][$arg] = $htmlform['value'] . $params[ $htmlform['name'] ];
 			}
 		}
 
@@ -227,7 +227,7 @@ class DataDumpPager extends TablePager {
 				$jobParams = [
 					'fileName' => $fileName,
 					'type' => $type,
-					'arguments' => $arguments ?? []
+					'arguments' => $args ?? []
 				];
 
 				$job = new DataDumpGenerateJob(

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -233,8 +233,6 @@ class DataDumpPager extends TablePager {
 					'type' => $type,
 					'arguments' => $args[$type]['generate']['arguments'] ?? []
 				];
-				
-				print_r($jobParams['arguments']);
 
 				$job = new DataDumpGenerateJob(
 					Title::newFromText( 'Special:DataDump' ), $jobParams );

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -183,15 +183,16 @@ class DataDumpPager extends TablePager {
 				continue;
 			}
 
-			$arguments = $type['generate']['arguments'] ?? [];
 			$htmlform = $type['htmlform'];
 			
-			if ( $htmlform['noArgsValue'] == $params[ $htmlform['name'] ] ) {
+			if ( ( $htmlform['noArgsValue'] ?? '' ) == $params[ $htmlform['name'] ] ) {
 				continue;	
 			}
 
+			$arguments = $type['generate']['arguments'] ?? [];
+
 			foreach ( $arguments as $arg => $value ) {
-				$args[$name]['generate']['arguments'][$arg] = $value . '=' . $htmlform['value'] . $params[ $htmlform['name'] ];
+				$args[$name]['generate']['arguments'][$arg] = $value . '=' . ( $htmlform['value'] ?? '' ) . $params[ $htmlform['name'] ];
 			}
 		}
 

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -185,6 +185,10 @@ class DataDumpPager extends TablePager {
 
 			$arguments = $type['generate']['arguments'] ?? [];
 			$htmlform = $type['htmlform'];
+			
+			if ( $htmlform['noArgsValue'] == $params[ $htmlform['name'] ] )
+				continue;	
+			}
 
 			foreach ( $arguments as $arg => $value ) {
 				$args[$name]['generate']['arguments'][$arg] = $value . '=' . $htmlform['value'] . $params[ $htmlform['name'] ];

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -227,7 +227,7 @@ class DataDumpPager extends TablePager {
 				$jobParams = [
 					'fileName' => $fileName,
 					'type' => $type,
-					'arguments' => $args ?? []
+					'arguments' => $args[$type]['generate']['options'] ?? []
 				];
 
 				$job = new DataDumpGenerateJob(

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -187,7 +187,7 @@ class DataDumpPager extends TablePager {
 			$htmlform = $type['htmlform'];
 
 			foreach ( $arguments as $arg => $value ) {
-				$args[$name]['generate']['arguments'][$arg] = $htmlform['value'] . $params[ $htmlform['name'] ];
+				$args[$name]['generate']['arguments'][$arg] = [ $value, $htmlform['value'] . $params[ $htmlform['name'] ] ];
 			}
 		}
 

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -57,7 +57,7 @@ class DataDumpGenerateJob extends Job {
 		if ( $dataDumpConfig[$type]['generate']['type'] === 'mwscript' ) {
 			$generate = array_merge(
 				$dataDumpConfig[$type]['generate']['options'],
-				$dataDumpConfig[$type]['generate']['arguments'],
+				$this->params['arguments'][$type]['generate']['arguments'],
 				[ '--wiki', $dbName ]
 			);
 

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -74,6 +74,7 @@ class DataDumpGenerateJob extends Job {
 				[
 					$dataDumpConfig[$type]['generate']['script']
 				],
+				$dataDumpConfig[$type]['generate']['arguments'],
 				$dataDumpConfig[$type]['generate']['options']
 			);
 

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -57,7 +57,7 @@ class DataDumpGenerateJob extends Job {
 		if ( $dataDumpConfig[$type]['generate']['type'] === 'mwscript' ) {
 			$generate = array_merge(
 				$dataDumpConfig[$type]['generate']['options'],
-				$this->params['arguments'][$type]['generate']['arguments'],
+				$this->params['arguments'],
 				[ '--wiki', $dbName ]
 			);
 

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -57,6 +57,7 @@ class DataDumpGenerateJob extends Job {
 		if ( $dataDumpConfig[$type]['generate']['type'] === 'mwscript' ) {
 			$generate = array_merge(
 				$dataDumpConfig[$type]['generate']['options'],
+				$dataDumpConfig[$type]['generate']['arguments'],
 				[ '--wiki', $dbName ]
 			);
 
@@ -74,7 +75,6 @@ class DataDumpGenerateJob extends Job {
 				[
 					$dataDumpConfig[$type]['generate']['script']
 				],
-				$dataDumpConfig[$type]['generate']['arguments'],
 				$dataDumpConfig[$type]['generate']['options']
 			);
 


### PR DESCRIPTION
Allows usages of `arguments` and `htmlform` in DataDump config. This should allow adding additional htmlform fields and arguments to add to mwscript based on their values.

Related: T7259