### PR TITLE
refactor(registration): Convert to new HookHandlers interface

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -90,13 +90,14 @@
 		"DataDumpPager": "includes/DataDumpPager.php",
 		"SpecialDataDump": "includes/specials/SpecialDataDump.php"
 	},
+	"HookHandlers": {
+		"default": {
+			"class": "DataDumpHooks"
+		}
+	},
 	"Hooks": {
-		"LoadExtensionSchemaUpdates": [
-			"DataDumpHooks::onLoadExtensionSchemaUpdates"
-		],
-		"SidebarBeforeOutput": [
-			"DataDumpHooks::onSidebarBeforeOutput"
-		]
+		"LoadExtensionSchemaUpdates": "default",
+		"SidebarBeforeOutput": "default"
 	},
 	"ConfigRegistry": {
 		"datadump": "GlobalVarConfig::newInstance"

--- a/includes/DataDumpHooks.php
+++ b/includes/DataDumpHooks.php
@@ -1,13 +1,16 @@
 <?php
 
+use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
+use MediaWiki\Hook\SidebarBeforeOutputHook;
+
 /**
  * Stores functions for hooks
  *
  * @author Paladox
  */
-class DataDumpHooks {
 
-	public static function onLoadExtensionSchemaUpdates( DatabaseUpdater $updater ) {
+class DataDumpHooks implements LoadExtensionSchemaUpdatesHook, SidebarBeforeOutputHook {
+	public function onLoadExtensionSchemaUpdates( $updater ) {
 		$updater->addExtensionTable(
 			'data_dump',
 			__DIR__ . '/../sql/data_dump.sql'
@@ -29,9 +32,9 @@ class DataDumpHooks {
 				__DIR__ . '/../sql/patches/patch-dumps_size-bigint.sql' );
 	}
 
-	public static function onSidebarBeforeOutput( $skin, &$bar ) {
-		if ( isset( $bar['managewiki-sidebar-header'] ) ) {
-			$bar['managewiki-sidebar-header'][] = [
+	public function onSidebarBeforeOutput( $skin, &$sidebar ): void{
+		if ( isset( $sidebar['managewiki-sidebar-header'] ) ) {
+			$sidebar['managewiki-sidebar-header'][] = [
 				'text' => wfMessage( 'datadump-link' )->text(),
 				'id' => 'datadumplink',
 				'href' => htmlspecialchars( SpecialPage::getTitleFor( 'DataDump' )->getFullURL() )

--- a/includes/DataDumpHooks.php
+++ b/includes/DataDumpHooks.php
@@ -32,7 +32,7 @@ class DataDumpHooks implements LoadExtensionSchemaUpdatesHook, SidebarBeforeOutp
 				__DIR__ . '/../sql/patches/patch-dumps_size-bigint.sql' );
 	}
 
-	public function onSidebarBeforeOutput( $skin, &$sidebar ): void{
+	public function onSidebarBeforeOutput( $skin, &$sidebar ): void {
 		if ( isset( $sidebar['managewiki-sidebar-header'] ) ) {
 			$sidebar['managewiki-sidebar-header'][] = [
 				'text' => wfMessage( 'datadump-link' )->text(),


### PR DESCRIPTION
Refactors hook registration to use the [new hook system](https://www.mediawiki.org/wiki/Manual:Hooks#Handling_hooks_in_MediaWiki_1.35_and_later).