### PR TITLE
Replace usages of deprecated wfWikiID()

### DIFF
--- a/includes/DataDump.php
+++ b/includes/DataDump.php
@@ -1,7 +1,6 @@
 <?php
 
 use MediaWiki\MediaWikiServices;
-use WikiMap;
 
 /**
  * Stores shared code to use in multiple places.

--- a/includes/DataDump.php
+++ b/includes/DataDump.php
@@ -1,6 +1,7 @@
 <?php
 
 use MediaWiki\MediaWikiServices;
+use WikiMap;
 
 /**
  * Stores shared code to use in multiple places.
@@ -25,7 +26,7 @@ class DataDump {
 				$uploadDir = $config->get( 'UploadDirectory' );
 				$backend = new FSFileBackend( [
 					'name'           => 'dumps-backend',
-					'wikiId'         => wfWikiID(),
+					'wikiId'         => WikiMap::getCurrentWikiId(),
 					'lockManager'    => new NullLockManager( [] ),
 					'containerPaths' => [ 'dumps-backup' => $dirConfig ?: "{$uploadDir}/dumps" ],
 					'fileMode'       => 0777,


### PR DESCRIPTION
The global function wfWikiID() is deprecated since 1.35 and it's usages
should be replaced with WikiMap::getCurrentWikiId().

Bug: https://phabricator.wikimedia.org/T298059