### PR TITLE
ApiViewDumps: return only raw download URL

### DIFF
--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -86,7 +86,7 @@ class ApiViewDumps extends ApiBase {
 			'dump' => $dump->dumps_filename
 		];
 
-		return $title->getFullUrl( $query );
+		return $title->getFullURL( $query );
 	}
 
 	public function getAllowedParams() {

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -80,15 +80,13 @@ class ApiViewDumps extends ApiBase {
 			return $url
 		}
 		
-		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-
 		$title = SpecialPage::getTitleFor( 'DataDump' );
 
 		$query = [
 			'dump' => $dump->dumps_filename
 		];
 
-		return $linkRenderer->getLinkURL( $title, $dump->dumps_filename, [], $query );
+		return $title->getFullUrl($query)
 	}
 
 	public function getAllowedParams() {

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -54,13 +54,42 @@ class ApiViewDumps extends ApiBase {
 
 				$buildResults[] = [
 					'filename' => $dump->dumps_filename,
-					'link' => $this->getDownloadUrl( $config, $dump ),
+					'htmllink' => $this->getDownloadUrl( $config, $dump ),
+					'link' => $this->getUrl( $config, $dump ),
 					'time' => $dump->dumps_timestamp ?: '',
 					'type' => $dump->dumps_type,
 				];
 			}
 		}
 		$this->getResult()->addValue( null, $this->getModuleName(), $buildResults );
+	}
+	
+	private function getUrl( $config, $dump ) {
+		// Do not create a link if the file has not been created.
+		if ( (int)$dump->dumps_completed !== 1 ) {
+			return $dump->dumps_filename;
+		}
+		
+		// If wgDataDumpDownloadUrl is configured, use that
+		// rather than using the internal streamer.
+		if ( $config->get( 'DataDumpDownloadUrl' ) ) {
+			$url = preg_replace(
+				'/\$\{filename\}/im',
+				$dump->dumps_filename,
+				$config->get( 'DataDumpDownloadUrl' )
+			);
+			return $url
+		}
+		
+		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
+
+		$title = SpecialPage::getTitleFor( 'DataDump' );
+
+		$query = [
+			'dump' => $dump->dumps_filename
+		];
+
+		return $linkRenderer->getLinkURL( $title, $dump->dumps_filename, [], $query );
 	}
 
 	private function getDownloadUrl( $config, $dump ) {

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -86,7 +86,7 @@ class ApiViewDumps extends ApiBase {
 			'dump' => $dump->dumps_filename
 		];
 
-		return $title->getFullUrl( $query )
+		return $title->getFullUrl( $query );
 	}
 
 	public function getAllowedParams() {

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -54,7 +54,6 @@ class ApiViewDumps extends ApiBase {
 
 				$buildResults[] = [
 					'filename' => $dump->dumps_filename,
-					'htmllink' => $this->getDownloadUrl( $config, $dump ),
 					'link' => $this->getUrl( $config, $dump ),
 					'time' => $dump->dumps_timestamp ?: '',
 					'type' => $dump->dumps_type,
@@ -90,35 +89,6 @@ class ApiViewDumps extends ApiBase {
 		];
 
 		return $linkRenderer->getLinkURL( $title, $dump->dumps_filename, [], $query );
-	}
-
-	private function getDownloadUrl( $config, $dump ) {
-		// Do not create a link if the file has not been created.
-		if ( (int)$dump->dumps_completed !== 1 ) {
-			return $dump->dumps_filename;
-		}
-
-		// If wgDataDumpDownloadUrl is configured, use that
-		// rather than using the internal streamer.
-		if ( $config->get( 'DataDumpDownloadUrl' ) ) {
-			$url = preg_replace(
-				'/\$\{filename\}/im',
-				$dump->dumps_filename,
-				$config->get( 'DataDumpDownloadUrl' )
-			);
-			return Linker::makeExternalLink( $url, $dump->dumps_filename );
-		}
-
-		$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
-
-		$title = SpecialPage::getTitleFor( 'DataDump' );
-
-		$query = [
-			'action' => 'download',
-			'dump' => $dump->dumps_filename
-		];
-
-		return $linkRenderer->makeLink( $title, $dump->dumps_filename, [], $query );
 	}
 
 	public function getAllowedParams() {

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -86,7 +86,7 @@ class ApiViewDumps extends ApiBase {
 			'dump' => $dump->dumps_filename
 		];
 
-		return $title->getFullUrl($query)
+		return $title->getFullUrl( $query )
 	}
 
 	public function getAllowedParams() {

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -54,7 +54,7 @@ class ApiViewDumps extends ApiBase {
 
 				$buildResults[] = [
 					'filename' => $dump->dumps_filename,
-					'link' => $this->getUrl( $config, $dump ),
+					'link' => $this->getDownloadUrl( $config, $dump ),
 					'time' => $dump->dumps_timestamp ?: '',
 					'type' => $dump->dumps_type,
 				];
@@ -62,13 +62,13 @@ class ApiViewDumps extends ApiBase {
 		}
 		$this->getResult()->addValue( null, $this->getModuleName(), $buildResults );
 	}
-	
-	private function getUrl( $config, $dump ) {
+
+	private function getDownloadUrl( $config, $dump ) {
 		// Do not create a link if the file has not been created.
 		if ( (int)$dump->dumps_completed !== 1 ) {
 			return $dump->dumps_filename;
 		}
-		
+
 		// If wgDataDumpDownloadUrl is configured, use that
 		// rather than using the internal streamer.
 		if ( $config->get( 'DataDumpDownloadUrl' ) ) {
@@ -77,7 +77,7 @@ class ApiViewDumps extends ApiBase {
 				$dump->dumps_filename,
 				$config->get( 'DataDumpDownloadUrl' )
 			);
-			return $url
+			return $url;
 		}
 		
 		$title = SpecialPage::getTitleFor( 'DataDump' );


### PR DESCRIPTION
This pull request replaces the current "link" response, which returns an HTML element, with a new one that returns only the URL of the dump.

These changes are made with the use-case of a client that manages these dumps through the API in mind. For these clients, currently the only way to retrieve the URL to the dump is to include an HTML parser and try to retrieve it from the href attribute of the a element inside the link response. Implementing these changes would make life easier for them