### PR TITLE
ApiViewDumps: Add "action=download" parameter back

### DIFF
--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -83,7 +83,7 @@ class ApiViewDumps extends ApiBase {
 		$title = SpecialPage::getTitleFor( 'DataDump' );
 
 		$query = [
-			'action' => 'download'
+			'action' => 'download',
 			'dump' => $dump->dumps_filename
 		];
 

--- a/includes/api/ApiViewDumps.php
+++ b/includes/api/ApiViewDumps.php
@@ -83,6 +83,7 @@ class ApiViewDumps extends ApiBase {
 		$title = SpecialPage::getTitleFor( 'DataDump' );
 
 		$query = [
+			'action' => 'download'
 			'dump' => $dump->dumps_filename
 		];
 


### PR DESCRIPTION
This pull request fixes an oversight in https://github.com/miraheze/DataDump/pull/54, where the download GET parameter was removed in the "no DataDumpDownloadUrl" path. This parameter is required in order for Special:DataDump to stream the file over to the client (https://github.com/miraheze/DataDump/blob/dbe0b3fa140f2f619576a35e53bd38662d9a55f2/includes/specials/SpecialDataDump.php#L62).