### PR TITLE
Create a few maintenance scripts

### DIFF
--- a/maintenance/deleteOldDumps.php
+++ b/maintenance/deleteOldDumps.php
@@ -1,0 +1,49 @@
+<?php
+
+$IP = getenv( 'MW_INSTALL_PATH' );
+if ( $IP === false ) {
+	$IP = __DIR__ . '/../../..';
+}
+
+require_once "$IP/maintenance/Maintenance.php";
+
+class DeleteOldDumps extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription( 'Delete the oldest dumps if the dump limit is exceeded' );
+		$this->requireExtension( 'DataDump' );
+	}
+
+	public function execute() {
+		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'datadump' );
+
+		$db = $this->getDB( DB_PRIMARY );
+		$res = $db->select( 'data_dump', '*', [], __METHOD__, [ 'ORDER BY' => 'dumps_timestamp ASC' ] );
+
+		$backend = DataDump::getBackend();
+		$storagePath = $backend->getContainerStoragePath( 'dumps-backup' );
+
+		$dumpCount = 0;
+		foreach ( $res as $row ) {
+			$dumpType = $row->dumps_type;
+			$dumpLimit = $config->get( 'DataDump' )[$dumpType]['limit'];
+
+			if ( $dumpLimit < 0 ) {
+				continue;
+			}
+
+			$dumpCount++;
+			if ( $dumpCount > $dumpLimit ) {
+				# Delete the dump from the data_dump table
+				$db->delete( 'data_dump', [ 'dumps_filename' => $row->dumps_filename ], __METHOD__ );
+
+				# Delete the dump file from storage
+				$backend->delete( [ 'src' => "$storagePath/{$row->dumps_filename}" ] );
+			}
+		}
+	}
+}
+
+$maintClass = DeleteOldDumps::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/deleteOldDumps.php
+++ b/maintenance/deleteOldDumps.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 $IP = getenv( 'MW_INSTALL_PATH' );
 if ( $IP === false ) {
 	$IP = __DIR__ . '/../../..';

--- a/maintenance/deleteUnknownDumps.php
+++ b/maintenance/deleteUnknownDumps.php
@@ -1,0 +1,50 @@
+<?php
+
+$IP = getenv( 'MW_INSTALL_PATH' );
+if ( $IP === false ) {
+	$IP = __DIR__ . '/../../..';
+}
+
+require_once "$IP/maintenance/Maintenance.php";
+
+class DeleteUnknownDumps extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription( 'Delete all dumps with types that do not exist in the $wgDataDump configuration' );
+		$this->addOption( 'dry-run', 'Do not delete any dumps, just output what would be deleted' );
+
+		$this->requireExtension( 'DataDump' );
+	}
+
+	public function execute() {
+		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'datadump' );
+		$dumpTypes = array_keys( $config->get( 'Dumps' ) );
+		$dryRun = $this->getOption( 'dry-run', false );
+
+		$db = $this->getDB( DB_PRIMARY );
+		$res = $db->select( 'data_dump', '*', [], __METHOD__ );
+
+		$backend = DataDump::getBackend();
+		$storagePath = $backend->getContainerStoragePath( 'dumps-backup' );
+
+		foreach ( $res as $row ) {
+			if ( !in_array( $row->dumps_type, $dumpTypes ) ) {
+				if ( !$dryRun ) {
+					# Delete the dump from the data_dump table
+					$db->delete( 'data_dump', [ 'dumps_filename' => $row->dumps_filename ], __METHOD__ );
+
+					# Delete the dump file from storage
+					$backend->delete( [ 'src' => "$storagePath/{$row->dumps_filename}" ] );
+				} else {
+					# Output what would be deleted if this was not a dry run
+					$this->output( "Would delete dump with filename {$row->dumps_filename} and type {$row->dumps_type}\n" );
+				}
+			}
+		}
+
+		$this->output( "Done\n" );
+	}
+}
+
+$maintClass = DeleteUnknownDumps::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/deleteUnknownDumps.php
+++ b/maintenance/deleteUnknownDumps.php
@@ -19,7 +19,7 @@ class DeleteUnknownDumps extends Maintenance {
 	public function execute() {
 		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'datadump' );
 
-		$dumpTypes = array_keys( $config->get( 'Dumps' ) );
+		$dumpTypes = array_keys( $config->get( 'DataDump' ) );
 		$dryRun = $this->getOption( 'dry-run', false );
 
 		$db = $this->getDB( DB_PRIMARY );

--- a/maintenance/deleteUnknownDumps.php
+++ b/maintenance/deleteUnknownDumps.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 $IP = getenv( 'MW_INSTALL_PATH' );
 if ( $IP === false ) {
 	$IP = __DIR__ . '/../../..';

--- a/maintenance/deleteUnknownDumps.php
+++ b/maintenance/deleteUnknownDumps.php
@@ -18,6 +18,7 @@ class DeleteUnknownDumps extends Maintenance {
 
 	public function execute() {
 		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'datadump' );
+
 		$dumpTypes = array_keys( $config->get( 'Dumps' ) );
 		$dryRun = $this->getOption( 'dry-run', false );
 

--- a/maintenance/importMissingDumps.php
+++ b/maintenance/importMissingDumps.php
@@ -63,7 +63,7 @@ class ImportMissingDumps extends Maintenance {
 				'dumps_filename' => $dump,
 				'dumps_failed' => 0,
 				'dumps_size' => $fileSize,
-				'dumps_timestamp' => $db->timestamp( $fileStat['mtime'] ),
+				'dumps_timestamp' => $db->timestamp( $fileStat['mtime'] ?? 0 ),
 				'dumps_type' => $dumpType
 			] );
 		}

--- a/maintenance/importMissingDumps.php
+++ b/maintenance/importMissingDumps.php
@@ -38,8 +38,11 @@ class ImportMissingDumps extends Maintenance {
 
 		$missingDumps = array_diff( array_keys( $dumpFiles ), $existingDumps );
 		foreach ( $missingDumps as $dump ) {
-			# Get the file size and extension
 			$fileSize = $backend->getFileSize( [
+				'src' => "$storagePath/$dump"
+			] );
+
+			$fileStat = $backend->getFileStat( [
 				'src' => "$storagePath/$dump"
 			] );
 
@@ -60,7 +63,7 @@ class ImportMissingDumps extends Maintenance {
 				'dumps_filename' => $dump,
 				'dumps_failed' => 0,
 				'dumps_size' => $fileSize,
-				'dumps_timestamp' => date( 'YmdHis' ),
+				'dumps_timestamp' => $db->timestamp( $fileStat['mtime'] ),
 				'dumps_type' => $dumpType
 			] );
 		}

--- a/maintenance/importMissingDumps.php
+++ b/maintenance/importMissingDumps.php
@@ -1,0 +1,71 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+
+$IP = getenv( 'MW_INSTALL_PATH' );
+if ( $IP === false ) {
+	$IP = __DIR__ . '/../../..';
+}
+
+require_once "$IP/maintenance/Maintenance.php";
+
+class ImportMissingDumps extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription( 'Import missing dumps from the backend to the data_dump table' );
+		$this->requireExtension( 'DataDump' );
+	}
+
+	public function execute() {
+		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'datadump' );
+
+		$db = $this->getDB( DB_PRIMARY );
+		$res = $db->select( 'data_dump', '*' );
+
+		$existingDumps = [];
+		foreach ( $res as $row ) {
+			$existingDumps[] = $row->dumps_filename;
+		}
+
+		$backend = DataDump::getBackend();
+		$storagePath = $backend->getContainerStoragePath( 'dumps-backup' );
+		$dumpFiles = $backend->getFileList( [
+			'dir' => $storagePath,
+			'adviseStat' => true,
+			'topOnly' => true
+		] );
+
+		$missingDumps = array_diff( array_keys( $dumpFiles ), $existingDumps );
+		foreach ( $missingDumps as $dump ) {
+			# Get the file size and extension
+			$fileSize = $backend->getFileSize( [
+				'src' => "$storagePath/$dump"
+			] );
+
+			$fileExtension = substr( $dump, strrpos( $dump, '.' ) + 1 );
+
+			# Determine the dump type
+			$dumpType = 'unknown';
+			foreach ( $config->get( 'DataDump' ) as $type => $config ) {
+				if ( $config['file_ending'] == ".$fileExtension" ) {
+					$dumpType = $type;
+					break;
+				}
+			}
+
+			# Insert the dump into the data_dump table
+			$db->insert( 'data_dump', [
+				'dumps_completed' => 1,
+				'dumps_filename' => $dump,
+				'dumps_failed' => 0,
+				'dumps_size' => $fileSize,
+				'dumps_timestamp' => date( 'YmdHis' ),
+				'dumps_type' => $dumpType
+			] );
+		}
+	}
+}
+
+$maintClass = ImportMissingDumps::class;
+require_once RUN_MAINTENANCE_IF_MAIN;


### PR DESCRIPTION
* ImportMissingDumps: regenerate the data_dump table from backend
* DeleteOldDumps: delete the oldest dumps from database and backend if the dump limit is exceeded
* DeleteUnknownDumps: Delete all dumps from database and backend with types that do not exist in the `$wgDataDump` configuration