### PR TITLE
Improvements to DataDump

### DIFF
--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -312,7 +312,7 @@ class DataDumpPager extends TablePager {
 		$config = $this->config->get( 'DataDump' );
 
 		if ( isset( $config[$type]['limit'] ) && $config[$type]['limit'] ) {
-			$row = $this->mDb->selectRow(
+			$res = $this->mDb->select(
 				'data_dump',
 				'*',
 				[
@@ -322,7 +322,7 @@ class DataDumpPager extends TablePager {
 
 			$limit = (int)$config[$type]['limit'];
 
-			if ( (int)$row < $limit ) {
+			if ( $res->numRows() < $limit ) {
 				return true;
 			} else {
 				$this->getOutput()->addHTML(

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -320,16 +320,16 @@ class DataDumpPager extends TablePager {
 				]
 			);
 
-			$limit = (int)$config[$type]['limit'];
+			$limit = $config[$type]['limit'];
 
-			if ( $res->numRows() > $limit ) {
+			if ( (int)$res->numRows() < (int)$limit ) {
+				return true;
+			} else {
 				$this->getOutput()->addHTML(
 					Html::errorBox( $this->msg( 'datadump-generated-error', $limit )->escaped() )
 				);
 
 				return false;
-			} else {
-				return true;
 			}
 		}
 

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -210,9 +210,10 @@ class DataDumpPager extends TablePager {
 			$htmlFormGenerate->prepareForm()
 				->displayForm( false );
 		} else {
+			$htmlFormGenerate->show();
+
 			$htmlFormGenerate->prepareForm()
-				->displayForm( true )
-				->show();
+				->displayForm( true );
 		}
 	}
 

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -154,13 +154,6 @@ class DataDumpPager extends TablePager {
 
 		$user = $this->getContext()->getUser();
 
-		if ( $user->getBlock() ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentNullable
-			throw new UserBlockedError( $user->getBlock() );
-		} elseif ( $user->isBlockedGlobally() ) {
-			throw new UserBlockedError( $user->getGlobalBlock() );
-		}
-
 		foreach ( $dataDumpConfig as $name => $value ) {
 			$perm = $dataDumpConfig[$name]['permissions']['generate'] ?? 'generate-dump';
 			if ( $this->permissionManager->userHasRight( $user, $perm ) ) {
@@ -218,14 +211,6 @@ class DataDumpPager extends TablePager {
 			return true;
 		}
 
-		$user = $this->getContext()->getUser();
-		if ( $user->getBlock() ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentNullable
-			throw new UserBlockedError( $user->getBlock() );
-		} elseif ( $user->isBlockedGlobally() ) {
-			throw new UserBlockedError( $user->getGlobalBlock() );
-		}
-
 		$dataDumpConfig = $this->config->get( 'DataDump' );
 		$dbName = $this->config->get( 'DBname' );
 
@@ -260,6 +245,7 @@ class DataDumpPager extends TablePager {
 				return;
 			}
 
+			$user = $this->getContext()->getUser();
 			$perm = $dataDumpConfig[$type]['permissions']['generate'];
 			if ( !$this->permissionManager->userHasRight( $user, $perm ) ) {
 				throw new PermissionsError( $perm );

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -204,17 +204,9 @@ class DataDumpPager extends TablePager {
 		$htmlFormGenerate = HTMLForm::factory( 'ooui', $formDescriptor, $this->getContext(), 'searchForms' );
 		$htmlFormGenerate->setMethod( 'post' )
 			->setFormIdentifier( 'generateDumpForm' )
-			->setSubmitCallback( [ $this, 'onGenerate' ] );
-
-		if ( $this->getRequest()->getVal( 'wpTarget' ) === null ) {
-			$htmlFormGenerate->prepareForm()
-				->displayForm( false );
-		} else {
-			$htmlFormGenerate->show();
-
-			$htmlFormGenerate->prepareForm()
-				->displayForm( true );
-		}
+			->setSubmitCallback( [ $this, 'onGenerate' ] )
+			->prepareForm()
+			->show();
 	}
 
 	public function onGenerate( array $params ) {
@@ -248,7 +240,7 @@ class DataDumpPager extends TablePager {
 			}
 		}
 
-		$type = $params['generatedumptype'] ?? '';
+		$type = $params['generatedumptype'];
 		if ( $type ) {
 			if ( !isset( $dataDumpConfig[$type] ) ) {
 				$out->addHTML(

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -322,14 +322,14 @@ class DataDumpPager extends TablePager {
 
 			$limit = (int)$config[$type]['limit'];
 
-			if ( $res->numRows() < $limit ) {
-				return true;
-			} else {
+			if ( $res->numRows() > $limit ) {
 				$this->getOutput()->addHTML(
 					Html::errorBox( $this->msg( 'datadump-generated-error', $limit )->escaped() )
 				);
 
 				return false;
+			} else {
+				return true;
 			}
 		}
 

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -210,7 +210,8 @@ class DataDumpPager extends TablePager {
 			$htmlFormGenerate->prepareForm()
 				->displayForm( false );
 		} else {
-			$htmlFormGenerate->show();
+			$htmlFormGenerate->show()
+				->displayForm( true );
 		}
 	}
 

--- a/includes/DataDumpPager.php
+++ b/includes/DataDumpPager.php
@@ -210,8 +210,9 @@ class DataDumpPager extends TablePager {
 			$htmlFormGenerate->prepareForm()
 				->displayForm( false );
 		} else {
-			$htmlFormGenerate->show()
-				->displayForm( true );
+			$htmlFormGenerate->prepareForm()
+				->displayForm( true )
+				->show();
 		}
 	}
 

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -5,8 +5,6 @@ use MediaWiki\Shell\Shell;
 
 /**
  * Used to generate dump
- *
- * @phan-file-suppress PhanTypeInvalidDimOffset
  */
 class DataDumpGenerateJob extends Job {
 	/** @var Config */

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -26,7 +26,9 @@ class DataDumpGenerateJob extends Job {
 			->getMaintenanceConnectionRef( DB_PRIMARY );
 
 		$fileName = $this->params['fileName'];
-		$type = $this->params['type'];
+		$type = (string)$this->params['type'];
+
+		$this->setStatus( 'in-progress', $dbw, '', $fileName, __METHOD__ );
 
 		$options = [];
 		foreach ( $dataDumpConfig[$type]['generate']['options'] as $option ) {
@@ -34,8 +36,6 @@ class DataDumpGenerateJob extends Job {
 		}
 
 		$dataDumpConfig[$type]['generate']['options'] = $options;
-
-		$this->status( 'in-progress', $dbw, '', $fileName, __METHOD__ );
 
 		$backend = DataDump::getBackend();
 		$directoryBackend = $backend->getContainerStoragePath( 'dumps-backup' );
@@ -88,17 +88,17 @@ class DataDumpGenerateJob extends Job {
 				] );
 
 				if ( !$status->isOK() ) {
-					return $this->status( 'failed', $dbw, '', $fileName, __METHOD__ );
+					return $this->setStatus( 'failed', $dbw, '', $fileName, __METHOD__ );
 				}
 			}
 
-			return $this->status( 'completed', $dbw, $directoryBackend, $fileName, __METHOD__ );
+			return $this->setStatus( 'completed', $dbw, $directoryBackend, $fileName, __METHOD__ );
 		}
 
-		return $this->status( 'failed', $dbw, '', $fileName, __METHOD__ );
+		return $this->setStatus( 'failed', $dbw, '', $fileName, __METHOD__ );
 	}
 
-	private function status( string $status, $dbw, string $directoryBackend, string $fileName, $fname ) {
+	private function setStatus( string $status, $dbw, string $directoryBackend, string $fileName, $fname ) {
 		$backend = DataDump::getBackend();
 		if ( $status === 'in-progress' ) {
 			$dbw->update(

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -5,6 +5,8 @@ use MediaWiki\Shell\Shell;
 
 /**
  * Used to generate dump
+ *
+ * @phan-file-suppress PhanTypeInvalidDimOffset
  */
 class DataDumpGenerateJob extends Job {
 	/** @var Config */

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -89,19 +89,16 @@ class DataDumpGenerateJob extends Job {
 					'dst' => $directoryBackend . '/' . $fileName,
 				] );
 
-				if ( !$status->isOK() ) {
-					return $this->setStatus( 'failed', $dbw, '', $fileName, __METHOD__ );
+				if ( $status->isOK() ) {
+					return $this->setStatus( 'completed', $dbw, $directoryBackend, $fileName, __METHOD__ );
 				}
 			}
-
-			return $this->setStatus( 'completed', $dbw, $directoryBackend, $fileName, __METHOD__ );
 		}
 
-		return $this->setStatus( 'failed', $dbw, '', $fileName, __METHOD__ );
+		return $this->setStatus( 'failed', $dbw, $directoryBackend, $fileName, __METHOD__ );
 	}
 
 	private function setStatus( string $status, $dbw, string $directoryBackend, string $fileName, $fname ) {
-		$backend = DataDump::getBackend();
 		if ( $status === 'in-progress' ) {
 			$dbw->update(
 				'data_dump',
@@ -119,6 +116,7 @@ class DataDumpGenerateJob extends Job {
 				unlink( wfTempDir() . '/' . $fileName );
 			}
 
+			$backend = DataDump::getBackend();
 			$size = $backend->getFileSize( [ 'src' => $directoryBackend . '/' . $fileName ] );
 			$dbw->update(
 				'data_dump',
@@ -131,7 +129,7 @@ class DataDumpGenerateJob extends Job {
 				],
 				$fname
 			);
-		} else {
+		} elseif ( $status === 'failed' ) {
 			if ( file_exists( wfTempDir() . '/' . $fileName ) ) {
 				// If the file somehow exists in the temp directory,
 				// but the command failed, we still want to delete it

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -28,7 +28,7 @@ class DataDumpGenerateJob extends Job {
 			->getMaintenanceConnectionRef( DB_PRIMARY );
 
 		$fileName = $this->params['fileName'];
-		$type = (string)$this->params['type'];
+		$type = $this->params['type'];
 
 		$this->setStatus( 'in-progress', $dbw, '', $fileName, __METHOD__ );
 

--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -110,6 +110,7 @@ class DataDumpGenerateJob extends Job {
 				],
 				$fname
 			);
+			$dbw->commit( __METHOD__, 'flush' );
 		} elseif ( $status === 'completed' ) {
 			if ( file_exists( wfTempDir() . '/' . $fileName ) ) {
 				// And now we remove the file from the temp directory, if it exists
@@ -129,6 +130,7 @@ class DataDumpGenerateJob extends Job {
 				],
 				$fname
 			);
+			$dbw->commit( __METHOD__, 'flush' );
 		} elseif ( $status === 'failed' ) {
 			if ( file_exists( wfTempDir() . '/' . $fileName ) ) {
 				// If the file somehow exists in the temp directory,
@@ -146,6 +148,7 @@ class DataDumpGenerateJob extends Job {
 				],
 				$fname
 			);
+			$dbw->commit( __METHOD__, 'flush' );
 		}
 
 		return true;

--- a/includes/specials/SpecialDataDump.php
+++ b/includes/specials/SpecialDataDump.php
@@ -27,6 +27,7 @@ class SpecialDataDump extends SpecialPage {
 		$this->outputHeader();
 
 		$this->checkPermissions();
+		$this->checkReadOnly();
 
 		$out = $this->getOutput();
 


### PR DESCRIPTION
* Removes block checks in Pager class as it's done before the form gets executed so these were duplicate checks.
* Fix issue with status not being updated to in-progress when job is ran.
* Check for read only in the special page. We don't want people creating dumps during read only.