### PR TITLE
Fix bug with setting status to completed

### DIFF
--- a/includes/jobs/DataDumpGenerateJob.php
+++ b/includes/jobs/DataDumpGenerateJob.php
@@ -98,6 +98,8 @@ class DataDumpGenerateJob extends Job {
 				if ( $status->isOK() ) {
 					return $this->setStatus( 'completed', $dbw, $directoryBackend, $fileName, __METHOD__ );
 				}
+			} else {
+				return $this->setStatus( 'completed', $dbw, $directoryBackend, $fileName, __METHOD__ );
 			}
 		}
 


### PR DESCRIPTION
Some aren't configured to set useBackendTempStore as some scripts does this within themselves.